### PR TITLE
Add sitecustomize to get rid of dirty packages

### DIFF
--- a/python/BUILD
+++ b/python/BUILD
@@ -21,3 +21,9 @@ exports_files([
     "whl.bzl",
     "__init__.py",
 ])
+
+py_library(
+    name = "site",
+    srcs = [":sitecustomize.py"],
+    imports = ["."],
+)

--- a/python/sitecustomize.py
+++ b/python/sitecustomize.py
@@ -1,0 +1,9 @@
+import sys
+import site
+
+# Call site.addsitedir() for all PYTHONPATH entries inside runfiles.
+# This causes any .pth files to be processed.  Without this, .pth files are not processed
+# and some namespace packages (like google.*) will not work.
+for p in sys.path:
+    if ".runfiles/" in p:
+        site.addsitedir(p)

--- a/python/whl.bzl
+++ b/python/whl.bzl
@@ -36,6 +36,9 @@ def _extract_wheels(ctx, wheels):
         args += ["--add-build-content=%s" % ctx.path(ctx.attr.additional_build_content)]
     args += ["--extras=%s" % extra for extra in ctx.attr.extras]
 
+    # Add our sitecustomize.py that ensures all .pth files are run.
+    args += ["--add-dependency=@io_bazel_rules_python//python:site"]
+
     result = ctx.execute(args, quiet=False)
     if result.return_code:
         fail("extract_wheels failed: %s (%s)" % (result.stdout, result.stderr))


### PR DESCRIPTION
Google packages start working if we evaluate *.pth files that
they provide.  Add a single sitecustomize.py file, and add it as a
dependency to every pip package.  sitecustomize.py (when found from
the PYTHONPATH) will be evaulated at the beginning, and we use it
to call site.addsitedir() to evaluate the *.pth files.