### PR TITLE
Add retry logic and local fallback to remote wheel caching

### DIFF
--- a/python/whl.bzl
+++ b/python/whl.bzl
@@ -182,7 +182,11 @@ download_or_build_wheel = repository_rule(
         ),
     },
     implementation = _download_or_build_wheel_impl,
-    environ = ["BAZEL_WHEEL_CACHE"],
+    environ = [
+        "BAZEL_WHEEL_CACHE",
+        "BAZEL_WHEEL_REMOTE_RETRY_ATTEMPTS",
+        "BAZEL_WHEEL_LOCAL_FALLBACK",
+    ],
 )
 
 


### PR DESCRIPTION
Adds 2 new environment variables:
- BAZEL_WHEEL_REMOTE_RETRY_ATTEMPTS: Number of retry attempts
    when fetching a wheel from remote http cache.
- BAZEL_WHEEL_LOCAL_FALLBACK: Set to "1" to enable fallback to
    local build when remote cache connection fails.