### PR TITLE
Three fixes reported by therc

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -162,6 +162,11 @@ load(
 _extras_install()
 
 wheel_overrides = {
+    "nvidia-ml-py": {
+        "name": "examples_checked_in_requirements_bzl__nvidia_ml_py_375_53",
+        "version": "375.53",
+        "wheel_name": "nvidia_ml_py-375.53.1-py2-none-any.whl",
+    },
     "pycuda": {
         "additional_buildtime_deps": ["numpy"],
     },

--- a/examples/checked_in_requirements_bzl/BUILD
+++ b/examples/checked_in_requirements_bzl/BUILD
@@ -26,9 +26,10 @@ py_test(
         requirement("jsonnet"),
         requirement("networkx"),
         requirement("numpy"),
+        requirement("nvidia-ml-py"),
         requirement("pyhive"),
+        requirement("scipy"),
         requirement("sqlalchemy"),
         requirement("tensorflow"),
-        requirement("nvidia-ml-py"),
     ],
 )

--- a/examples/checked_in_requirements_bzl/BUILD
+++ b/examples/checked_in_requirements_bzl/BUILD
@@ -29,5 +29,6 @@ py_test(
         requirement("pyhive"),
         requirement("sqlalchemy"),
         requirement("tensorflow"),
+        requirement("nvidia-ml-py"),
     ],
 )

--- a/examples/checked_in_requirements_bzl/requirements.bzl
+++ b/examples/checked_in_requirements_bzl/requirements.bzl
@@ -7,7 +7,7 @@ wheels = {
         "name": "examples_checked_in_requirements_bzl__absl_py_0_7_0",
         "version": "0.7.0",
         "wheel_name": "absl_py-0.7.0-py2-none-any.whl",
-        "sha256": "8352eeedf369f1bc99c3d0cef990edc73f90d3cdf84d8e8039b05ed489dab7e3",
+        "sha256": "2c4daee4c57b7085a7b1f48dc7eccd0de30ac9e5d252f7084ee142bd1a3fbe0b",
     },
     "astor": {
         "name": "examples_checked_in_requirements_bzl__astor_0_7_1",
@@ -25,7 +25,7 @@ wheels = {
         "name": "examples_checked_in_requirements_bzl__backports_ssl_match_hostname_3_5_0_1",
         "version": "3.5.0.1",
         "wheel_name": "backports.ssl_match_hostname-3.5.0.1-py2-none-any.whl",
-        "sha256": "7690d36d45ee6f5eb8df573f024b888af43297e3a9d51a202acac57a5a9f997a",
+        "sha256": "7108b3a3f6b4854964fec080199d0d02ef0dc8adaff0a2c38ac031537faf95f8",
     },
     "backports.weakref": {
         "name": "examples_checked_in_requirements_bzl__backports_weakref_1_0_post1",
@@ -61,7 +61,7 @@ wheels = {
         "name": "examples_checked_in_requirements_bzl__future_0_17_1",
         "version": "0.17.1",
         "wheel_name": "future-0.17.1-py2-none-any.whl",
-        "sha256": "ad16a51b2bff7537c08498e8568e827c24f25c62f7cbbcf06c2486ceb909af81",
+        "sha256": "05f6671ccebbf3dbf11ced962f04d904b7ec6bbab36eb4de5fd845f3e3f84387",
     },
     "futures": {
         "name": "examples_checked_in_requirements_bzl__futures_3_2_0",
@@ -73,7 +73,7 @@ wheels = {
         "name": "examples_checked_in_requirements_bzl__gast_0_2_2",
         "version": "0.2.2",
         "wheel_name": "gast-0.2.2-py2-none-any.whl",
-        "sha256": "a5a5c42f28817212ea436a5466500cc826252f8b36eec34a85f3eb9bcd7e773f",
+        "sha256": "5cd0d5ffc6c6131f5ef3c13436187e0b167f04f51ae3ce0fe9273f1fc9210838",
     },
     "grpcio": {
         "name": "examples_checked_in_requirements_bzl__grpcio_1_18_0",
@@ -91,14 +91,14 @@ wheels = {
         "name": "examples_checked_in_requirements_bzl__horovod_0_13_11",
         "version": "0.13.11",
         "wheel_name": "horovod-0.13.11-cp27-cp27mu-linux_x86_64.whl",
-        "sha256": "ecba1dad380cfc58b9e298b57de507274b1dedab6438d98ed2df06e3fe7e67b5",
+        "sha256": "aa6d85f80855fceb0df55fb9ee8c1efe91477e90ba07729a7d7a6cbec9421a12",
         "build_deps": ["absl-py", "astor", "backports.weakref", "cffi", "enum34", "funcsigs", "futures", "gast", "grpcio", "h5py", "keras-applications", "keras-preprocessing", "markdown", "mock", "numpy", "pandas", "pbr", "protobuf", "pycparser", "python-dateutil", "pytz", "setuptools", "six", "tensorboard", "tensorflow", "termcolor", "werkzeug", "wheel"],
     },
     "jsonnet": {
         "name": "examples_checked_in_requirements_bzl__jsonnet_0_11_2",
         "version": "0.11.2",
         "wheel_name": "jsonnet-0.11.2-cp27-cp27mu-linux_x86_64.whl",
-        "sha256": "d82434dddc3594ba4603a380090aefbc134497d8a70048f9a4e82c72f2adc7b6",
+        "sha256": "d380656573148de54f2eeb2f6d6b3274b80d2aec4abaca079280100aa6417c52",
     },
     "keras-applications": {
         "name": "examples_checked_in_requirements_bzl__Keras_Applications_1_0_7",
@@ -128,8 +128,8 @@ wheels = {
         "name": "examples_checked_in_requirements_bzl__networkx_2_2",
         "version": "2.2",
         "wheel_name": "networkx-2.2-py2.py3-none-any.whl",
-        "sha256": "8b8f0d30cc135c396949286c315e2c09aaa3df0cba0db938229afb313b9a74ff",
-        "extras": ["numpy", "pandas"],
+        "sha256": "d9d247182d4d8a8f1802f71bf0c443554e0a9a3e8b9ca546f92f5e0cfb1ca8c1",
+        "extras": ["numpy", "pandas", "scipy"],
     },
     "numpy": {
         "name": "examples_checked_in_requirements_bzl__numpy_1_16_0",
@@ -165,13 +165,13 @@ wheels = {
         "name": "examples_checked_in_requirements_bzl__pycparser_2_19",
         "version": "2.19",
         "wheel_name": "pycparser-2.19-py2.py3-none-any.whl",
-        "sha256": "5d9648d849e99d477ce4033716a779346f4222ee443e04727503a638f3092444",
+        "sha256": "fdeec454ad279b8151021a4435c5089832a2fad15828f103259036222eb91d82",
     },
     "pyhive": {
         "name": "examples_checked_in_requirements_bzl__PyHive_0_6_1",
         "version": "0.6.1",
         "wheel_name": "PyHive-0.6.1-py2-none-any.whl",
-        "sha256": "a13c7518cdb2c89e17936a991415d93aabf559e891039a3cb91fc7a9acd40054",
+        "sha256": "5e5d4e1bb7151fb36d23ff35131d4bbb93b7b6bd5fa6e7eac43d3ff83d351275",
         "extras": ["sqlalchemy"],
     },
     "python-dateutil": {
@@ -185,6 +185,12 @@ wheels = {
         "version": "2018.9",
         "wheel_name": "pytz-2018.9-py2.py3-none-any.whl",
         "sha256": "32b0891edff07e28efe91284ed9c31e123d84bea3fd98e1f72be2508f43ef8d9",
+    },
+    "scipy": {
+        "name": "examples_checked_in_requirements_bzl__scipy_1_1_0",
+        "version": "1.1.0",
+        "wheel_name": "scipy-1.1.0-cp27-cp27mu-manylinux1_x86_64.whl",
+        "sha256": "08237eda23fd8e4e54838258b124f1cd141379a5f281b0a234ca99b38918c07a",
     },
     "setuptools": {
         "name": "examples_checked_in_requirements_bzl__setuptools_40_7_1",
@@ -203,7 +209,7 @@ wheels = {
         "name": "examples_checked_in_requirements_bzl__SQLAlchemy_1_1_15",
         "version": "1.1.15",
         "wheel_name": "SQLAlchemy-1.1.15-cp27-cp27mu-linux_x86_64.whl",
-        "sha256": "f49290bef79b5797b166999ca63ca6c1afe70eb51518e6822e48c9251362ba66",
+        "sha256": "06c0c4b4f010c63d39c7c384d9fead1e959fafc7b161030baf4aec3ef4e1079f",
     },
     "tensorboard": {
         "name": "examples_checked_in_requirements_bzl__tensorboard_1_12_2",
@@ -221,7 +227,7 @@ wheels = {
         "name": "examples_checked_in_requirements_bzl__termcolor_1_1_0",
         "version": "1.1.0",
         "wheel_name": "termcolor-1.1.0-py2-none-any.whl",
-        "sha256": "f4369cf998737829f92eb6aa76662a212bc7c7039fd9ed7d83468bd851abe64d",
+        "sha256": "232e3cd57fd206fd0e194ca73194d5bf23e65b350166a6877538c29a76727a6a",
     },
     "werkzeug": {
         "name": "examples_checked_in_requirements_bzl__Werkzeug_0_14_1",
@@ -240,6 +246,6 @@ wheels = {
         "name": "examples_checked_in_requirements_bzl__wrapt_1_11_1",
         "version": "1.11.1",
         "wheel_name": "wrapt-1.11.1-cp27-cp27mu-linux_x86_64.whl",
-        "sha256": "578bc77e810965d4e6f27295def82a699e7b0e2eca0923b8fc0b28a0d4f0ff59",
+        "sha256": "38249b4c3f557b9cef9dfbd0c48939adeadeb37cb48e7e71f3f32ab48da6191f",
     },
 }

--- a/examples/checked_in_requirements_bzl/requirements.txt
+++ b/examples/checked_in_requirements_bzl/requirements.txt
@@ -6,6 +6,7 @@ jsonnet==0.11.2
 networkx==2.2
 pandas
 pyhive==0.6.1
+scipy==1.1.0
 sqlalchemy==1.1.15
 tensorflow==1.12.0
 wrapt==1.11.1

--- a/examples/checked_in_requirements_bzl/version_test.py
+++ b/examples/checked_in_requirements_bzl/version_test.py
@@ -12,23 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pip
-import unittest
-
-
-class VersionTest(unittest.TestCase):
-
-  def test_version(self):
-    self.assertEqual(pip.__version__, '9.0.0')
-
-import keras as k
-print(k)
-
-import google.auth as auth
-print(auth)
-
-import google.cloud as cl
-print(cl)
-
-if __name__ == '__main__':
-  unittest.main()
+import pynvml
+from scipy.stats import kendalltau

--- a/python/pip.bzl
+++ b/python/pip.bzl
@@ -60,7 +60,10 @@ sh_binary(
 
     ctx.file(
         "update.sh",
-        "#!/bin/bash\n'%s' \"$@\"\n" % "' '".join(cmd),
+        "\n".join([
+            "#!/bin/bash",
+            "'%s' \"$@\"" % "' '".join(cmd),
+        ]),
         executable = True,
     )
 
@@ -74,6 +77,16 @@ sh_binary(
 
     if result.return_code:
         fail("pip_import failed: %s (%s)" % (result.stdout, result.stderr))
+
+    ctx.file(
+        "update.sh",
+        " ".join([
+            "#!/bin/bash",
+            "echo requirements_bzl attribute is mandatory for checked-in requirements",
+            "exit 1",
+        ]),
+        executable = True,
+    )
 
 _pip_import = repository_rule(
     attrs = {

--- a/python/pip.bzl
+++ b/python/pip.bzl
@@ -161,6 +161,8 @@ load("{repo}//:requirements.bzl", wheels_{key} = "wheels")
 
     gathers = "".join(["""\
     for k, v in wheels_{key}.items():
+        if "name" not in v:
+            continue
         if k not in all_reqs:
             all_reqs[k] = {{}}
         all_reqs[k]["{key}"] = "@%s//:pkg" % v["name"]

--- a/rules_python/piptool.py
+++ b/rules_python/piptool.py
@@ -711,7 +711,7 @@ def resolve(args):
       try:
         sha256 = build_wheel(
           distribution=w.distribution(),
-          version=w.version(),
+          version=build_info.get(w.name(), {}).get("version", w.version()),
           directory=tempdir,
           # NOTE: The build-dir here must match the one that we use in the
           # individual build_wheel() rules later, otherwise the sha256 that we

--- a/rules_python/requirements.bzl.tpl
+++ b/rules_python/requirements.bzl.tpl
@@ -17,7 +17,12 @@ def _merged_wheels():
         "pip_args": _pip_args,
         "python": _python,
     }
-    return {k: v + default_attrs + _additional_attributes.get(k, {}) for k, v in _wheels.items()}
+    # Merge _additional_attributes with _wheels, applying default_attrs to each item.
+    return {
+        k: default_attrs + v for k, v in _additional_attributes.items()
+    } + {
+        k: default_attrs + v + _additional_attributes.get(k, {}) for k, v in _wheels.items()
+    }
 
 wheels = _merged_wheels()
 
@@ -36,6 +41,8 @@ def requirement(name, target = "pkg", binary = None):
 
 def pip_install():
     for distribution, attributes in wheels.items():
+        if "name" not in attributes:
+            continue
         wheel = attributes.get("wheel", None)
         if not wheel:
             wheel = download_or_build_wheel(distribution = distribution)

--- a/rules_python/whl.py
+++ b/rules_python/whl.py
@@ -153,12 +153,6 @@ class Wheel(object):
                 shutil.move(os.path.join(purelib_path, s), os.path.join(directory, s))
             break
 
-    # Add empty init files where needed
-    for current_dir, _, filelist in os.walk(directory):
-        if current_dir != directory and '__init__.py' not in filelist:
-            with open(os.path.join(current_dir, '__init__.py'), 'w') as f:
-                pass
-
   # _parse_metadata parses METADATA files according to https://www.python.org/dev/peps/pep-0314/
   def _parse_metadata(self, content):
     name_pattern = re.compile('Name: (.*)')


### PR DESCRIPTION
- Print helpful message if user runs :update without requirements_bzl attribute (Issue #17)
- Don't generate empty `__init__.py` files (Issue #16)
     - These can cause problems such as Issue #16.
- Support adding new wheels via requirements_overrides (Issue #19)
    - Sometimes it's convenient to add a new wheel via requirements_overrides,
     to add a user-built / self-hosted wheel, or to work around wheels that
     cannot be resolved.  As an example of the latter case, add nvidia-ml-py
     which must be installed with "pip install nvidia-ml-py==375.53", but
    actually produces a wheel with version 375.53.1.
- Bake files.pythonhosted.org URL into checked-in requirements.bzl for faster download
