### PR TITLE
Iterate over copy of sys.path in sitecustomize

### DIFF
--- a/python/sitecustomize.py
+++ b/python/sitecustomize.py
@@ -4,6 +4,6 @@ import site
 # Call site.addsitedir() for all PYTHONPATH entries inside runfiles.
 # This causes any .pth files to be processed.  Without this, .pth files are not processed
 # and some namespace packages (like google.*) will not work.
-for p in sys.path:
+for p in list(sys.path):
     if ".runfiles/" in p:
         site.addsitedir(p)


### PR DESCRIPTION
Integration to VS Code ptvsd debugger fails, because pathis changed as a side effect of site.addsitedir.