### PR TITLE
Use tree artifacts for extracted wheels to reduce the amount of symlinks

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -61,9 +61,14 @@ _piptool_install()
 
 http_archive(
     name = "subpar",
-    urls = ["https://github.com/google/subpar/archive/07ff5feb7c7b113eea593eb6ec50b51099cf0261.tar.gz"],
-    sha256 = "a694bd35ff4be79a49fbb6e5fd6b1c9083ef05cd752409f5fe349f6d74432fd8",
-    strip_prefix = "subpar-07ff5feb7c7b113eea593eb6ec50b51099cf0261",
+    urls = ["https://github.com/google/subpar/archive/a4f9b23bf01bcc7a52d458910af65a90ee991aff.tar.gz"],
+    sha256 = "cf3762b10426a1887d37f127b4c1390785ecb969254096eb714cc1db371f78d6",
+    strip_prefix = "subpar-a4f9b23bf01bcc7a52d458910af65a90ee991aff",
+    patch_args = ["-p1"],
+    patches = [
+        # https://github.com/google/subpar/pull/92
+        "//:third_party/subpar/support-directories-in-manifest.patch",
+    ],
 )
 
 # Test data for WHL tool testing.

--- a/python/python.bzl
+++ b/python/python.bzl
@@ -12,6 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+WheelInfo = provider(
+    fields = {
+        "distribution": "distribution (string)",
+        "version": "version (string)",
+    },
+)
+
 def py_library(*args, **kwargs):
   """See the Bazel core py_library documentation.
 
@@ -35,3 +42,70 @@ def py_test(*args, **kwargs):
   https://docs.bazel.build/versions/master/be/python.html#py_test).
   """
   native.py_test(*args, **kwargs)
+
+def _extract_wheel_impl(ctx):
+    d = ctx.actions.declare_directory("extracted")
+    command = ["BUILDDIR=$(pwd)"]
+    command += ["%s extract --whl=%s --directory=%s" % (ctx.executable._piptool.path, ctx.file.wheel.path, d.path)]
+    inputs = [ctx.file.wheel]
+    outputs = [d]
+    tools = [ctx.executable._piptool]
+
+    command += ["cd %s" % d.path]
+    for patchfile in ctx.files.patches:
+        command += ["{patchtool} {patch_args} < $BUILDDIR/{patchfile}".format(
+            patchtool = ctx.attr.patch_tool,
+            patchfile = patchfile.path,
+            patch_args = " ".join([
+                "'%s'" % arg
+                for arg in ctx.attr.patch_args
+            ]),
+        )]
+        inputs += [patchfile]
+
+    command += ctx.attr.patch_cmds
+
+    ctx.actions.run_shell(
+        inputs = inputs,
+        outputs = outputs,
+        tools = tools,
+        command = " && ".join(command),
+        mnemonic = "ExtractWheel",
+    )
+
+    return struct(
+        py = struct(transitive_sources = depset(direct=[d])),
+        providers = [
+            DefaultInfo(
+                files = depset(direct = outputs),
+                runfiles = ctx.runfiles(files = [d]),
+            ),
+            WheelInfo(
+                distribution = ctx.attr.distribution,
+                version = ctx.attr.version,
+            ),
+        ],
+    )
+
+extract_wheel = rule(
+    implementation = _extract_wheel_impl,
+    attrs = {
+        "wheel": attr.label(
+            doc = "A wheel to extract.",
+            allow_single_file = [".whl"],
+        ),
+        "deps": attr.label_list(default = []),
+        "patches": attr.label_list(default = [], allow_files=True),
+        "patch_tool": attr.string(default = "patch"),
+        "patch_args": attr.string_list(default = ["-p0"]),
+        "patch_cmds": attr.string_list(default = []),
+        "distribution": attr.string(),
+        "version": attr.string(),
+        "_piptool": attr.label(
+            allow_files = True,
+            executable = True,
+            default = Label("//tools:piptool.par"),
+            cfg = "host",
+        ),
+    },
+)

--- a/python/whl.bzl
+++ b/python/whl.bzl
@@ -32,7 +32,7 @@ def _extract_wheel(ctx, wheel):
     args = [
         python,
         ctx.path(ctx.attr._piptool),
-        "extract",
+        "genbuild",
         "--directory", str(ctx.path("")),
         "--repository", ctx.attr.repository,
     ]
@@ -47,12 +47,19 @@ def _extract_wheel(ctx, wheel):
     # Add our sitecustomize.py that ensures all .pth files are run.
     args += ["--add-dependency=@io_bazel_rules_python//python:site"]
 
-    _report_progress(ctx, "Extracting")
+    for x in ctx.attr.patches:
+        args += ["--patches=@%s" % x]
+    if ctx.attr.patch_tool:
+        args += ["--patch-tool=%s" % ctx.attr.patch_tool]
+    for x in ctx.attr.patch_args:
+        args += ["--patch-args=%s" % x]
+    for x in ctx.attr.patch_cmds:
+        args += ["--patch-cmds=%s" % x]
+
+    _report_progress(ctx, "Genbuild")
     result = ctx.execute(args, quiet=False)
     if result.return_code:
-        fail("extract_wheel failed: %s (%s)" % (result.stdout, result.stderr))
-
-    patch(ctx)
+        fail("wheel genbuild failed: %s (%s)" % (result.stdout, result.stderr))
 
 
 def _build_wheel(ctx):


### PR DESCRIPTION
Previously, we would extract the wheel in the repository rule (during
loading/analysis phase) and define a py_library rule that globs all
extracted files into the "srcs" and "data" attributes.  This results in
each individual file being separately symlinked into the runfiles
directory, which creates LOTS of symlinks.

This change reduces the amount of symlinks by not extracting the wheel
in the repository rule, and instead instantiating a new "extract_wheel"
build rule that uses ctx.actions.declare_directory to declare a
directory artifact into which the wheel is extracted during the build
phase.

In the piptool code, this is implemented by splitting the old "piptool
extract" command into two: "piptool genbuild" that is ran in the loading
phase to generate the "extract_wheel" rule, and "piptool extract" that
is now invoked by the new "extract_wheel" rule in the build phase.
Patching also happens in the build phase now, so all patching commands
need to be propagated as attributes to the "extract_wheel" rule.