### PR TITLE
Use clean env when building wheels

### DIFF
--- a/python/pip.bzl
+++ b/python/pip.bzl
@@ -35,6 +35,7 @@ sh_binary(
       "%{python_version}": ctx.attr.python_version if ctx.attr.python_version else "",
       "%{pip_args}": ", ".join(["\"%s\"" % arg for arg in ctx.attr.pip_args]),
       "%{additional_attributes}": ctx.attr.requirements_overrides or "{}",
+      "%{env}": ", ".join(["\"%s\"" % x for x in ctx.attr.env]),
     })
 
 
@@ -66,7 +67,7 @@ sh_binary(
         "\n".join([
             "#!/bin/bash",
             "rm -rf \"%s\"" % str(ctx.path("build-directory")),
-            "'%s' \"$@\"" % "' '".join(cmd),
+            "exec env - %s '%s' \"$@\"" % (" ".join(ctx.attr.env), "' '".join(cmd)),
         ]),
         executable = True,
     )
@@ -102,6 +103,7 @@ _pip_import = repository_rule(
             allow_single_file = True,
         ),
         "requirements_overrides": attr.string(),
+        "env": attr.string_list(),
         "pip_args": attr.string_list(),
         "digests": attr.bool(default = False),
         "python_version": attr.string(values = ["PY2", "PY3", ""]),

--- a/rules_python/requirements.bzl.tpl
+++ b/rules_python/requirements.bzl.tpl
@@ -12,6 +12,7 @@ _python = "%{python}" or None
 _python_version = "%{python_version}" or None
 _repository = "%{repo}"
 _additional_attributes = %{additional_attributes}
+_env = [%{env}]
 
 def _merged_wheels():
     default_attrs = {
@@ -59,6 +60,7 @@ def download_or_build_wheel(distribution, rule=_download_or_build_wheel, **kwarg
     attrs = {a: w.get(a, None) for a in _wheel_rules.download_or_build_wheel.attrs}
     attrs["distribution"] = distribution
     attrs["build_deps"] = [_wheel_target(wheels[k]) for k in w.get("build_deps", [])]
+    attrs["additional_buildtime_env"] = _env + (attrs.get("additional_buildtime_env", []) or [])
     attrs.update(kwargs)
     rule(
         name = "%s_wheel" % w["name"],


### PR DESCRIPTION
Also remove support for "BAZEL_WHEEL_CACHE" and related env vars.